### PR TITLE
Fix B2B-156 processing price endpoint for no schemas selected

### DIFF
--- a/app/Http/Requests/SchemaUpdateRequest.php
+++ b/app/Http/Requests/SchemaUpdateRequest.php
@@ -27,7 +27,7 @@ class SchemaUpdateRequest extends FormRequest
             'hidden' => ['nullable', 'boolean', 'declined_if:required,yes,on,1,true'],
             'required' => ['nullable', 'boolean'],
 
-            'default' => ['nullable', 'required_if:required,true', 'integer', 'min:0', 'max:' . count($this->options ?? [])],
+            'default' => ['nullable', 'required_if:required,true', 'integer', 'min:0'],
 
             'options' => ['nullable', 'array'],
             'options.*.translations' => ['sometimes', new Translations(['name'])],

--- a/app/Rules/UnlimitedShippingDate.php
+++ b/app/Rules/UnlimitedShippingDate.php
@@ -4,9 +4,9 @@ namespace App\Rules;
 
 use App\Models\Item;
 use App\Services\Contracts\DepositServiceContract;
-use Carbon\Carbon;
 use Illuminate\Contracts\Validation\Rule;
 use Illuminate\Support\Facades\App;
+use Illuminate\Support\Facades\Date;
 
 class UnlimitedShippingDate implements Rule
 {
@@ -22,7 +22,7 @@ class UnlimitedShippingDate implements Rule
         if ($value === null) {
             return true;
         }
-        $shippingDate = Carbon::parse($value);
+        $shippingDate = Date::parse($value);
 
         $depositService = App::make(DepositServiceContract::class);
         $deposits = $depositService->getDepositsGroupByDateForItem($this->item, 'DESC');
@@ -31,7 +31,7 @@ class UnlimitedShippingDate implements Rule
             return true;
         }
 
-        $depositsDate = Carbon::parse($deposits[0]['shipping_date']);
+        $depositsDate = Date::parse($deposits[0]['shipping_date']);
 
         return !$shippingDate->isBefore($depositsDate);
     }

--- a/app/Services/DepositService.php
+++ b/app/Services/DepositService.php
@@ -7,7 +7,7 @@ use App\Models\Deposit;
 use App\Models\Item;
 use App\Models\OrderProduct;
 use App\Services\Contracts\DepositServiceContract;
-use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Date;
 
 final class DepositService implements DepositServiceContract
 {
@@ -113,7 +113,7 @@ final class DepositService implements DepositServiceContract
             ->whereNotNull('shipping_date')
             ->where('item_id', '=', $item->getKey())
             ->where('from_unlimited', '=', false)
-            ->where('shipping_date', '>=', Carbon::now())
+            ->where('shipping_date', '>=', Date::now())
             ->groupBy(['shipping_date'])
             ->having('quantity', '>', '0')
             ->orderBy('shipping_date', $order)
@@ -242,11 +242,11 @@ final class DepositService implements DepositServiceContract
         bool $fromUnlimited,
     ): bool {
         if ($shippingTimeAndDate['shipping_date'] !== null) {
-            $shippingDate = Carbon::parse($shippingTimeAndDate['shipping_date']);
+            $shippingDate = Date::parse($shippingTimeAndDate['shipping_date']);
 
             $groupedDepositsByDate = $this->getDepositsGroupByDateForItem($item, 'DESC');
             foreach ($groupedDepositsByDate as $deposit) {
-                $depositDate = Carbon::parse($deposit['shipping_date']);
+                $depositDate = Date::parse($deposit['shipping_date']);
 
                 if (!$depositDate->isAfter($shippingDate) && $quantity > 0) {
                     $quantity -= $deposit['quantity'];
@@ -265,7 +265,7 @@ final class DepositService implements DepositServiceContract
             $groupedDepositsByTime = $this->getDepositsGroupByTimeForItem($item, 'DESC');
             foreach ($groupedDepositsByTime as $deposit) {
                 if (($deposit['shipping_time'] <= $shippingTimeAndDate['shipping_time']
-                        || $shippingTimeAndDate['shipping_time'] === null) && $quantity > 0) {
+                    || $shippingTimeAndDate['shipping_time'] === null) && $quantity > 0) {
                     $quantity -= $deposit['quantity'];
                     $this->removeFromWarehouse(
                         $orderProduct,

--- a/app/Services/ProductService.php
+++ b/app/Services/ProductService.php
@@ -203,8 +203,12 @@ final readonly class ProductService
 
         $price_initial = $product->mappedPriceForPriceMap($priceMap);
 
-        $sales = $this->discountService->getAllAplicableSalesForProduct($product, $this->discountService->getSalesWithBlockList(), $calculateForCurrentUser);
-        $price = $this->discountService->calcAllDiscountsOnProductVariant($product, $sales, $salesChannel, $dto->schemas);
+        if (is_array($dto->schemas) && !empty($dto->schemas)) {
+            $sales = $this->discountService->getAllAplicableSalesForProduct($product, $this->discountService->getSalesWithBlockList(), $calculateForCurrentUser);
+            $price = $this->discountService->calcAllDiscountsOnProductVariant($product, $sales, $salesChannel, $dto->schemas);
+        } else {
+            $price = ProductCachedPriceDto::from($price_initial, $salesChannel);
+        }
 
         return ProductVariantPriceResource::from([
             'price_initial' => ProductCachedPriceDto::from($price_initial, $salesChannel),

--- a/database/migrations/2024_08_29_000001_create_sales_channel_for_each_default_price_map.php
+++ b/database/migrations/2024_08_29_000001_create_sales_channel_for_each_default_price_map.php
@@ -1,6 +1,5 @@
 <?php
 
-use App\Models\Price;
 use App\Models\Product;
 use App\Services\ProductService;
 use Domain\Currency\Currency;

--- a/database/migrations/2024_09_04_000000_change_schema_default_to_option_ids.php
+++ b/database/migrations/2024_09_04_000000_change_schema_default_to_option_ids.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+use Domain\ProductSchema\Models\Schema as ProductSchema;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Migrations\Migration;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        ProductSchema::query()->with('options')->chunkById(100, function (Collection $schemas) {
+            /** @var ProductSchema $schema */
+            foreach ($schemas as $schema) {
+                $default = is_numeric($schema->default) ? intval($schema->default) : null;
+
+                if ($default === null) {
+                    continue;
+                }
+
+                $default_option = $schema->options->get($default, $schema->options->last());
+                $schema->default = $default_option?->getKey();
+                $schema->saveQuietly();
+            }
+        });
+    }
+
+    public function down(): void {}
+};

--- a/src/Domain/Price/PriceRepository.php
+++ b/src/Domain/Price/PriceRepository.php
@@ -40,7 +40,7 @@ final class PriceRepository
         /** @var ProductCachedPricesDto $pricesCollection */
         foreach ($priceMatrix as $pricesCollection) {
             foreach ($pricesCollection->prices as $price) {
-                $salesChannel = $salesChannels->firstOrFail($price->sales_channel_id);
+                $salesChannel = $salesChannels->firstOrFail('id', '=', $price->sales_channel_id);
 
                 $rows[] = [
                     'id' => Uuid::uuid4(),

--- a/src/Domain/PriceMap/Resources/PriceMapProductPriceData.php
+++ b/src/Domain/PriceMap/Resources/PriceMapProductPriceData.php
@@ -20,8 +20,8 @@ final class PriceMapProductPriceData extends DataWithGlobalMetadata
     public static function fromModel(PriceMapProductPrice $price): static
     {
         return new self(
-            $price->price_map_id,
-            $price->map?->name ?? '',
+            $price->map?->id ?? 'MAP_DELETED',
+            $price->map?->name ?? 'MAP_DELETED',
             $price->is_net,
             $price->currency->value,
             (string) $price->value->getAmount(),

--- a/src/Domain/PriceMap/Resources/PriceMapSchemaPricesOptionPriceDetailedData.php
+++ b/src/Domain/PriceMap/Resources/PriceMapSchemaPricesOptionPriceDetailedData.php
@@ -20,8 +20,8 @@ final class PriceMapSchemaPricesOptionPriceDetailedData extends DataWithGlobalMe
     public static function fromModel(PriceMapSchemaOptionPrice $price): static
     {
         return new self(
-            $price->price_map_id,
-            $price->map?->name ?? '',
+            $price->map?->id ?? 'MAP_DELETED',
+            $price->map?->name ?? 'MAP_DELETED',
             $price->is_net,
             $price->currency->value,
             (string) $price->value->getAmount(),

--- a/src/Domain/Product/Dtos/ProductVariantPriceDto.php
+++ b/src/Domain/Product/Dtos/ProductVariantPriceDto.php
@@ -5,13 +5,14 @@ declare(strict_types=1);
 namespace Domain\Product\Dtos;
 
 use Spatie\LaravelData\Data;
+use Spatie\LaravelData\Optional;
 
 final class ProductVariantPriceDto extends Data
 {
     /**
-     * @param array<string,string> $schemas
+     * @param array<string,string>|Optional $schemas
      */
     public function __construct(
-        public array $schemas,
+        public array|Optional $schemas,
     ) {}
 }

--- a/src/Domain/ProductSchema/Services/SchemaCrudService.php
+++ b/src/Domain/ProductSchema/Services/SchemaCrudService.php
@@ -85,6 +85,12 @@ final readonly class SchemaCrudService
 
         $this->availabilityService->calculateSchemaAvailability($schema);
 
+        if (is_int($dto->default)) {
+            $default_option = $schema->options->get($dto->default, $schema->options->last());
+            $schema->default = $default_option?->getKey();
+            $schema->saveQuietly();
+        }
+
         return $schema;
     }
 


### PR DESCRIPTION
Fix storing default schema option - store id of option (required by frontend) instead of option index (it depends on options order)